### PR TITLE
Utils Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,6 @@ Environment variables:
 | `MANGA_COVERS_URL_SUBDIRECTORY` | Path of the URL where images can be found (i.e.: `/static/manga`)      |
 | `MANGA_IMAGE_DIRECTORY`         | Path where images should be saved to (i.e. `/home/myuser/mangacovers`) |
 | `SQLITE_FILE_PATH`              | Path to the sqlite file                                                |
+| `DISCORD_HELPER_ROLE`           | Role allowed to use some advanced features                             |
+| `DISCORD_WEBHOOK`               | Webhook URL to send Discord announcements                              |
+| `DISCORD_LOGGER_CHANNEL`        | Channel id to be used as a log when errors arise or other information  |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import kotlin.io.path.readLines
 version = "0.0.1a"
 
 plugins {
-    kotlin("jvm") version "1.6.10"  // I hate that my LSP on Emacs can't get along with recent versions
+    kotlin("jvm") version "1.8.20"
     id("app.cash.sqldelight") version "2.0.0-alpha05"
     application
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ version = "0.0.1a"
 
 plugins {
     kotlin("jvm") version "1.8.20"
+    kotlin("plugin.serialization") version "1.6.10"
     id("app.cash.sqldelight") version "2.0.0-alpha05"
     application
 }
@@ -15,6 +16,7 @@ repositories {
 
 dependencies {
     implementation("dev.kord", "kord-core", "0.8.0-M17")
+
     implementation("app.cash.sqldelight", "sqlite-driver", "2.0.0-alpha05")
     implementation("app.cash.sqldelight", "primitive-adapters", "2.0.0-alpha05")
     implementation("org.slf4j", "slf4j-simple","2.0.7")
@@ -22,6 +24,13 @@ dependencies {
 
     implementation("com.twelvemonkeys.imageio", "imageio-jpeg", "3.9.4")
     implementation("com.twelvemonkeys.imageio", "imageio-webp", "3.9.4")
+
+    val ktorVersion = "2.3.0"
+
+    implementation("io.ktor", "ktor-client-core-jvm", ktorVersion)
+    implementation("io.ktor", "ktor-client-cio-jvm", ktorVersion)
+    implementation("io.ktor", "ktor-serialization-kotlinx-json-jvm", ktorVersion)
+    implementation("io.ktor", "ktor-client-content-negotiation-jvm", ktorVersion)
 }
 
 application {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import kotlin.io.path.div
 import kotlin.io.path.readLines
 
-version = "0.0.1a"
+version = "0.1.0a"
 
 plugins {
     kotlin("jvm") version "1.8.20"

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/App.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/App.kt
@@ -1,6 +1,8 @@
 package ar.pelotude.ohhsugoi
 
 import ar.pelotude.ohhsugoi.bot.MangaExtension
+import ar.pelotude.ohhsugoi.bot.UtilsExtension
+import ar.pelotude.ohhsugoi.db.scheduler.Scheduler
 import ar.pelotude.ohhsugoi.koin.botModule
 import com.kotlindiscord.kord.extensions.ExtensibleBot
 import com.kotlindiscord.kord.extensions.utils.getKoin
@@ -10,6 +12,7 @@ suspend fun main() {
     val kordEx = ExtensibleBot(System.getenv("KORD_TOKEN")) {
         extensions {
             add(::MangaExtension)
+            add { UtilsExtension<Long>() }
         }
 
         i18n {
@@ -19,6 +22,10 @@ suspend fun main() {
         hooks {
             afterKoinSetup {
                 getKoin().loadModules(listOf(botModule))
+            }
+
+            afterExtensionsAdded {
+                getKoin().get<Scheduler<*>>().synchronize()
             }
         }
     }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/GeneralConfiguration.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/GeneralConfiguration.kt
@@ -1,0 +1,11 @@
+package ar.pelotude.ohhsugoi.bot
+
+import dev.kord.common.entity.Snowflake
+
+interface GeneralConfiguration {
+    val guild: Snowflake
+}
+
+class GeneralConfigurationImpl(
+    override val guild: Snowflake
+) : GeneralConfiguration

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/GenericPostIdConverter.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/GenericPostIdConverter.kt
@@ -1,0 +1,58 @@
+package ar.pelotude.ohhsugoi.bot
+
+import com.kotlindiscord.kord.extensions.commands.Argument
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ConverterBuilder
+import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
+import com.kotlindiscord.kord.extensions.parser.StringParser
+import dev.kord.core.entity.interaction.OptionValue
+import dev.kord.core.entity.interaction.StringOptionValue
+import dev.kord.rest.builder.interaction.OptionsBuilder
+import dev.kord.rest.builder.interaction.StringChoiceBuilder
+import org.koin.core.component.get
+
+class GenericPostIdConverter<T : Any>(
+        override var validator: Validator<T> = null,
+        valueToIdConverter: (suspend (String, CommandContext) -> T)? = null
+
+) : SingleConverter<T>(), KordExKoinComponent {
+    override val signatureTypeString = "converters.genericPostId.signatureType"
+
+    private val valueToIdConverter: suspend (String, CommandContext) -> T = valueToIdConverter ?: get()
+
+    override suspend fun parse(parser: StringParser?, context: CommandContext, named: String?): Boolean {
+        throw UnsupportedOperationException("This converter only works with slash commands.")
+    }
+
+    override suspend fun parseOption(context: CommandContext, option: OptionValue<*>): Boolean {
+        val optionValue = (option as? StringOptionValue)?.value ?: return false
+
+        parsed = valueToIdConverter(optionValue, context)
+
+        return true
+    }
+
+    override suspend fun toSlashOption(arg: Argument<*>): OptionsBuilder {
+        return StringChoiceBuilder(arg.displayName, arg.description).apply {
+            maxLength = 100
+            required = true
+        }
+    }
+}
+
+class GenericPostIdConverterBuilder<T : Any> : ConverterBuilder<T>() {
+    override fun build(arguments: Arguments): SingleConverter<T> {
+        return arguments.arg(name, description, GenericPostIdConverter<T>().withBuilder(this))
+    }
+}
+
+fun <T : Any> Arguments.postId(body: GenericPostIdConverterBuilder<T>.() -> Unit): SingleConverter<T> {
+    val converterBuilder = GenericPostIdConverterBuilder<T>()
+    converterBuilder.body()
+    converterBuilder.validateArgument()
+
+    return converterBuilder.build(this)
+}

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaExtensionConfiguration.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/MangaExtensionConfiguration.kt
@@ -3,11 +3,11 @@ package ar.pelotude.ohhsugoi.bot
 import dev.kord.common.entity.Snowflake
 
 class MangaExtensionConfiguration(
-    val guild: Snowflake,
     val allowedRole: Snowflake,
     val mangaLinkMaxLength: Int,
     val mangaTitleMinLength: Int,
     val mangaTitleMaxLength: Int,
     val mangaDescMinLength: Int,
     val mangaDescMaxLength: Int,
-)
+    generalConfig: GeneralConfiguration
+) : GeneralConfiguration by generalConfig

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/UtilsExtension.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/UtilsExtension.kt
@@ -1,0 +1,409 @@
+package ar.pelotude.ohhsugoi.bot
+
+import ar.pelotude.ohhsugoi.db.UserData
+import ar.pelotude.ohhsugoi.db.UsersDatabase
+import ar.pelotude.ohhsugoi.db.scheduler.*
+import com.kotlindiscord.kord.extensions.checks.hasRole
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.application.slash.converters.impl.stringChoice
+import com.kotlindiscord.kord.extensions.commands.application.slash.ephemeralSubCommand
+import com.kotlindiscord.kord.extensions.commands.application.slash.publicSubCommand
+import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalRole
+import com.kotlindiscord.kord.extensions.commands.converters.impl.role
+import com.kotlindiscord.kord.extensions.commands.converters.impl.string
+import com.kotlindiscord.kord.extensions.components.forms.ModalForm
+import com.kotlindiscord.kord.extensions.extensions.Extension
+import com.kotlindiscord.kord.extensions.extensions.ephemeralSlashCommand
+import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
+import com.kotlindiscord.kord.extensions.types.respond
+import com.kotlindiscord.kord.extensions.types.respondingPaginator
+import dev.kord.core.behavior.channel.createMessage
+import dev.kord.core.behavior.interaction.suggestString
+import dev.kord.core.entity.Guild
+import dev.kord.core.entity.channel.TextChannel
+import dev.kord.core.exception.EntityNotFoundException
+import dev.kord.rest.builder.message.create.embed
+import dev.kord.rest.request.RestRequestException
+import kotlinx.coroutines.launch
+import org.koin.core.component.get
+import org.koin.core.component.inject
+import org.koin.core.qualifier.named
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+
+class UtilsExtension<T : Any> : Extension(), KordExKoinComponent, SchedulerEventHandler<T> {
+    override val name = "utils"
+
+    private val scheduler: Scheduler<T> = get<Scheduler<T>>().apply { subscribe(this@UtilsExtension) }
+    private val usersDatabase: UsersDatabase by inject()
+    private val config: UtilsExtensionConfiguration by inject()
+
+    private lateinit var loggerChannel: TextChannel
+
+    private val availableZoneIds = ZoneId.getAvailableZoneIds().toSortedSet()
+
+    // it might  be wiser to convert ULongs to RoleBehaviour and use their `.mention`
+    private fun ULong?.toMentionOn(guild: Guild): String? {
+        return when (this) {
+            null -> null
+            guild.id.value -> "@everyone"
+            else -> "<@&$this>"
+        }
+    }
+
+    inner class ScheduleArguments : Arguments() {
+        val date by date {
+            name = "fecha"
+            description = "Fecha de envío. Formato día/mes/año hora:minuto. Puedes omitir el año o la fecha por completo."
+        }
+
+        val mention by optionalRole {
+            name = "mención"
+            description = "Rol al que mencionar."
+        }
+    }
+
+    inner class ZoneIdArguments : Arguments() {
+        val zoneId by string {
+            name = "zona"
+            description = "Tu zona horaria."
+
+            maxLength = availableZoneIds.maxBy(String::length).length
+
+            autoComplete {
+                val typedIn = focusedOption.value
+                val matches = availableZoneIds.asSequence().filter { it.contains(typedIn, true) }.take(10)
+
+                suggestString {
+                    matches.forEach { id -> choice(id, id) }
+                }
+            }
+
+            validate {
+                failIfNot(value in availableZoneIds, "La zona no es válida.")
+            }
+        }
+    }
+
+    inner class SearchScheduledMessagesArguments : Arguments() {
+        val statusFilter by stringChoice {
+            name = "estado"
+            description = "Estado por el cual filtrar."
+
+            choices(statusFilters)
+        }
+    }
+
+    inner class DiscordMessageModal : ModalForm() {
+        override var title: String = "Mensaje programado de Discord."
+
+        val text= paragraphText {
+            label = "Mensaje de Discord."
+            maxLength = 1900
+            minLength = 1
+        }
+    }
+
+    open inner class ScheduledPostArguments : Arguments() {
+        val postId by postId<T> {
+            name = "id"
+            description = "Id de la publicación."
+        }
+    }
+
+    inner class EditDateArguments : ScheduledPostArguments() {
+        val date by date {
+            name = "fecha"
+            description = "Nueva fecha."
+        }
+    }
+
+    inner class EditMentionRoleArguments : ScheduledPostArguments() {
+        val mention by role {
+            name = "mención"
+            description = "Rol al que mencionar."
+        }
+    }
+
+    private val EVERYTHING = "EVERYTHING"
+
+    private val statusFilters = mapOf(
+        "pendiente" to Status.PENDING.name,
+        "fallido" to Status.FAILED.name,
+        "mandado" to Status.SENT.name,
+        "cancelado" to Status.CANCELLED.name,
+        "todo" to EVERYTHING
+    )
+
+    private fun statusFilterMap(name: String): Status? {
+        return when (name) {
+            EVERYTHING -> null
+            else -> Status.valueOf(name)
+        }
+    }
+
+    override suspend fun setup() {
+        loggerChannel = kord.getChannelOf<TextChannel>(get(named("loggerChannel")))
+            ?: throw EntityNotFoundException("Logger channel could not be found.")
+
+        val hourFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+        ephemeralSlashCommand {
+            name = "mensajes"
+            description = "Administra mensajes automatizados."
+            guild(config.guild)
+
+            check {
+                hasRole(config.schedulerRole)
+            }
+
+            publicSubCommand(::SearchScheduledMessagesArguments) {
+                name = "buscar"
+                description = "Lista los mensajes programados"
+
+                action {
+                    val posts = statusFilterMap(arguments.statusFilter).let { filter ->
+                        scheduler.getPosts(filter)
+                    }.sortedByDescending(ScheduledPostMetadataImpl<*>::execInstant)
+
+                    if (posts.isEmpty()) {
+                        respondWithInfo("No se encontraron mensajes programados.")
+                        return@action
+                    }
+
+                    respondingPaginator {
+                        timeoutSeconds = 60
+
+                        posts.chunked(5).forEach { postsChunk ->
+                            owner = user
+
+                            page {
+                                title = "Encontrados ${posts.size} mensaje${if (posts.size > 1) 's' else ""} de Discord"
+
+                                postsChunk.forEach { post ->
+                                    val status = when (post.status) {
+                                        Status.SENT -> "Enviado"
+                                        Status.PENDING -> "Pendiente"
+                                        Status.CANCELLED -> "Cancelado"
+                                        Status.FAILED -> "Fallido"
+                                    }
+
+                                    field {
+                                        name = "[#${post.id}] <t:${post.execInstant.epochSecond}:t> <t:${post.execInstant.epochSecond}:d> [$status]"
+                                        // TODO: avoid printing multiple newlines
+                                        value = (if (post.text.length >= 50) post.text.slice(0 until 47) + "..." else post.text)
+                                        inline = false
+                                    }
+                                }
+                                color = colors.success
+                            }
+                        }
+                    }.send()
+                }
+            }
+
+            ephemeralSubCommand(::ScheduleArguments, ::DiscordMessageModal) {
+                name = "crear"
+                description = "Programa un mensaje para mandar a Discord a cierta hora."
+
+                action { modal ->
+                    val dateInstant = arguments.date.toInstant()
+                    val scheduledMsg = scheduler.schedule(modal!!.text.value!!, dateInstant, arguments.mention?.id?.value)
+
+                    respondWithSuccess("""Mensaje de Discord [#${scheduledMsg.id}] programado exitosamente
+                        |
+                        |Momento de envío: <t:${dateInstant.epochSecond}:R> (<t:${dateInstant.epochSecond}:F>)
+                    """.trimMargin(), public=true)
+                }
+            }
+
+            ephemeralSubCommand(::ScheduledPostArguments) {
+                name = "ver"
+                description = "Muestra detalles de un mensaje programado de Discord"
+
+                action {
+                    val post = scheduler.get(arguments.postId)
+
+                    if (post == null) respondWithError("No existe la publicación `${arguments.postId}`")
+                    else respond {
+                        val status = when (post.status) {
+                            Status.SENT -> "Enviado"
+                            Status.PENDING -> "Pendiente"
+                            Status.CANCELLED -> "Cancelado"
+                            Status.FAILED -> "Fallido"
+                        }
+
+                        embed {
+                            title = "Mensaje de Discord [#${post.id}]"
+                            description = post.text
+
+                            field {
+                                name = "Mención"
+                                value = post.mentionId.toMentionOn(guild!!.asGuild()) ?: "Nadie"
+                            }
+
+                            field {
+                                name = "Fecha de envío"
+                                value = "<t:${post.execInstant.epochSecond}:F>"
+                            }
+
+                            field {
+                                name = "Estado"
+                                value = status
+                            }
+                        }
+                    }
+                }
+            }
+
+            ephemeralSubCommand(::ScheduledPostArguments) {
+                name = "cancelar"
+                description = "Cancela un mensaje programado de Discord"
+
+                action {
+                    if (scheduler.cancel(arguments.postId)) {
+                        respondWithSuccess("Cancelado")
+                    } else {
+                        respondWithError("No se pudo cancelar ninguna publicación con esa id." +
+                                    " Verifica que existe y que su estado esté pendiente de envío.")
+                    }
+                }
+            }
+
+            ephemeralSubCommand(::ScheduledPostArguments, ::DiscordMessageModal) {
+                name = "editartexto"
+                description = "Edita el texto de un mensaje programado de Discord"
+
+                action {modal ->
+                    val submittedEdition = modal!!.text.value!!
+
+                    scheduler.editPost(arguments.postId, submittedEdition).let { success ->
+                        if (success) respondWithSuccess("Editado el texto a:\n\n${submittedEdition}", public=true)
+                        else {
+                            val userGotDm = try {
+                                user.getDmChannel().createMessage {
+                                    embed {
+                                        title = "Texto de edición fallida para #${arguments.postId}."
+                                        description = submittedEdition
+                                        color = colors.error
+                                    }
+                                }
+                                true
+                            } catch (e: RestRequestException) {
+                                false
+                            }
+
+                            val description = "No se pudo cambiar el texto del mensaje #${arguments.postId}" + if (!userGotDm) {
+                                ". Cópialo para evitar perderlo:\n\n${submittedEdition}"
+                            } else {
+                                ". Tu texto te fue envíado por mensaje directo."
+                            }
+
+                            respondWithError(description)
+                        }
+                    }
+                }
+            }
+
+            ephemeralSubCommand(::EditDateArguments) {
+                name = "editarfecha"
+                description = "Edita la fecha de un mensaje programado de Discord"
+
+                action {
+                    val newExecInstant = arguments.date.toInstant()
+
+                    scheduler.editPost(arguments.postId, newExecInstant=newExecInstant).let { success ->
+                        if (success) {
+                            respondWithSuccess("Fecha de publicación del mensaje #${arguments.postId} cambiada a <t:${newExecInstant.epochSecond}:F>.")
+                        } else {
+                            respondWithError("No se pudo cambiar la fecha de publicación del mensaje #${arguments.postId}.")
+                        }
+                    }
+                }
+            }
+
+            ephemeralSubCommand(::EditMentionRoleArguments) {
+                name = "editarmención"
+                description = "Edita el rol a mencionar en un mensaje."
+
+                action {
+                    scheduler.editPost(k=arguments.postId, newMentionRole=arguments.mention.id.value).let { success ->
+                        if (success) {
+                            respondWithSuccess("Rol a mencionar de #${arguments.postId} cambiado a ${arguments.mention.mention}.")
+                        } else {
+                            respondWithError("No se pudo cambiar el rol del mensaje #${arguments.postId}.")
+                        }
+                    }
+                }
+            }
+
+            ephemeralSubCommand(::ScheduledPostArguments) {
+                name = "removermención"
+                description = "Remueve el rol a mencionar en un mensaje."
+
+                action {
+                    scheduler.removeMention(arguments.postId).let { success ->
+                        if (success) {
+                            respondWithSuccess("Rol a mencionar de la publicación #${arguments.postId} removido.")
+                        } else {
+                            respondWithError("No se pudo remover el rol del mensaje #${arguments.postId}.")
+                        }
+                    }
+                }
+            }
+        }
+
+        ephemeralSlashCommand {
+            name = "zonahoraria"
+            description = "Cambia o chequea tu zona horaria."
+            guild(config.guild)
+
+            ephemeralSubCommand(::ZoneIdArguments) {
+                name = "cambiar"
+                description = "Cambia tu zona horaria."
+
+                action {
+                    val zoneId = ZoneId.of(arguments.zoneId)
+                    val userData = UserData(user.id.value, zoneId)
+                    usersDatabase.setUser(userData)
+
+                    respondWithSuccess("""Zona cambiada a `${arguments.zoneId}`.
+                    |
+                    |Tu horario actual debería ser `${ZonedDateTime.now(zoneId).format(hourFormatter)}`
+                    |""".trimMargin(), public=true)
+                }
+            }
+
+            ephemeralSubCommand {
+                name = "ver"
+                description = "Mira cuál es tu zona horaria."
+
+                action {
+                    val zoneIdStr: String? = usersDatabase.getUser(user.id.value)?.zone?.toString()
+
+                    if (zoneIdStr != null) {
+                        val zoneId = ZoneId.of(zoneIdStr)
+
+                        respondWithInfo(
+                            """Tu zona es `$zoneIdStr`
+                            |
+                            |Tu horario actual debería ser `${ZonedDateTime.now(zoneId).format(hourFormatter)}`
+                            |""".trimMargin()
+                        )
+                    } else respondWithInfo("No tengo registrada tu zona horaria.")
+                }
+            }
+        }
+    }
+
+    override fun handle(e: ScheduleEvent<T>) {
+        kord.launch {
+            if (e is Failure<T>) {
+                loggerChannel.createMessage {
+                    content="Hubo un problema mandando un mensaje: `<id=${e.post.id}, description=${e.reason}>`"
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/UtilsExtensionConfiguration.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/UtilsExtensionConfiguration.kt
@@ -1,0 +1,8 @@
+package ar.pelotude.ohhsugoi.bot
+
+import dev.kord.common.entity.Snowflake
+
+class UtilsExtensionConfiguration(
+        val schedulerRole: Snowflake,
+        generalConfig: GeneralConfiguration,
+) : GeneralConfiguration by generalConfig

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/Views.kt
@@ -3,24 +3,26 @@ package ar.pelotude.ohhsugoi.bot
 import ar.pelotude.ohhsugoi.db.MangaWithTags
 import ar.pelotude.ohhsugoi.util.makeTitle
 import com.kotlindiscord.kord.extensions.checks.types.CheckContext
+import com.kotlindiscord.kord.extensions.commands.application.slash.EphemeralSlashCommandContext
 import com.kotlindiscord.kord.extensions.commands.application.slash.PublicSlashCommandContext
 import com.kotlindiscord.kord.extensions.components.components
 import com.kotlindiscord.kord.extensions.components.ephemeralButton
 import com.kotlindiscord.kord.extensions.types.edit
 import com.kotlindiscord.kord.extensions.types.respond
 import com.kotlindiscord.kord.extensions.types.respondEphemeral
+import com.kotlindiscord.kord.extensions.types.respondPublic
 import dev.kord.common.Color
 import dev.kord.core.entity.User
 import dev.kord.core.event.interaction.ButtonInteractionCreateEvent
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.embed
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import java.util.*
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 object colors {
     val info = Color (0, 0, 200)
@@ -128,36 +130,69 @@ suspend fun PublicSlashCommandContext<MangaExtension.EditArguments, *>.respondWi
     }
 }
 
-suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(description: String, title: String = "**Info**") {
-    respond {
-        embed {
-            this.title = title
-            this.description = description
+fun quickEmbed(title: String, description: String, color: Color) = EmbedBuilder().apply {
+    this.title = title
+    this.description = description
+    this.color = color
+}
 
-            color = colors.info
-        }
+suspend fun EphemeralSlashCommandContext<*, *>.respondWithInfo(description: String, title: String = "**Info**", public: Boolean = false) {
+    val embed = quickEmbed(title, description, colors.info)
+
+    if (public) respondPublic {
+        embeds.add(embed)
+    } else respond {
+        embeds.add(embed)
     }
 }
 
-suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: String, title: String = "**Éxito**") {
-    respond {
-        embed {
-            this.title = title
-            this.description = description
+suspend fun EphemeralSlashCommandContext<*, *>.respondWithSuccess(description: String, title: String = "**Éxito**", public: Boolean = false) {
+    val embed = quickEmbed(title, description, colors.success)
 
-            color = colors.success
-        }
+    if (public) respondPublic {
+        embeds.add(embed)
+    } else respond {
+        embeds.add(embed)
     }
 }
 
-suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String, title: String = "**Error**") {
-    respond {
-        embed {
-            this.title = title
-            this.description = description
+suspend fun EphemeralSlashCommandContext<*, *>.respondWithError(description: String, title: String = "**Error**", public: Boolean = false) {
+    val embed = quickEmbed(title, description, colors.error)
 
-            color = colors.error
-        }
+    if (public) respondPublic {
+        embeds.add(embed)
+    } else respond {
+        embeds.add(embed)
+    }
+}
+
+suspend fun PublicSlashCommandContext<*, *>.respondWithInfo(description: String, title: String = "**Info**", public: Boolean = true) {
+    val embed = quickEmbed(title, description, colors.info)
+
+    if (public) respond {
+        embeds.add(embed)
+    } else respondEphemeral {
+        embeds.add(embed)
+    }
+}
+
+suspend fun PublicSlashCommandContext<*, *>.respondWithSuccess(description: String, title: String = "**Éxito**", public: Boolean = true) {
+    val embed = quickEmbed(title, description, colors.success)
+
+    if (public) respond {
+        embeds.add(embed)
+    } else respondEphemeral {
+        embeds.add(embed)
+    }
+}
+
+suspend fun PublicSlashCommandContext<*, *>.respondWithError(description: String, title: String = "**Error**", public: Boolean = true) {
+    val embed = quickEmbed(title, description, colors.error)
+
+    if (public) respond {
+        embeds.add(embed)
+    } else respondEphemeral {
+        embeds.add(embed)
     }
 }
 

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/ZonedDateTimeConverter.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/ZonedDateTimeConverter.kt
@@ -20,7 +20,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeParseException
 
-class ZonedDateTimeConverter(override var validator: Validator<ZonedDateTime> = null) : SingleConverter<ZonedDateTime>(), KordExKoinComponent{
+class ZonedDateTimeConverter(override var validator: Validator<ZonedDateTime> = null) : SingleConverter<ZonedDateTime>(), KordExKoinComponent {
     override val signatureTypeString: String = "converters.zdt.signatureType"
 
     private val pattern: String = "d/M/yyyy H:mm"
@@ -31,7 +31,7 @@ class ZonedDateTimeConverter(override var validator: Validator<ZonedDateTime> = 
     private val userDatabase: UsersDatabase by inject()
 
     override suspend fun parse(parser: StringParser?, context: CommandContext, named: String?): Nothing {
-        throw UnsupportedOperationException()
+        throw UnsupportedOperationException("This converter only works with slash commands.")
     }
 
     override suspend fun parseOption(context: CommandContext, option: OptionValue<*>): Boolean {

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/bot/ZonedDateTimeConverter.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/bot/ZonedDateTimeConverter.kt
@@ -1,0 +1,94 @@
+package ar.pelotude.ohhsugoi.bot
+
+import ar.pelotude.ohhsugoi.db.UsersDatabase
+import com.kotlindiscord.kord.extensions.DiscordRelayedException
+import com.kotlindiscord.kord.extensions.commands.Argument
+import com.kotlindiscord.kord.extensions.commands.Arguments
+import com.kotlindiscord.kord.extensions.commands.CommandContext
+import com.kotlindiscord.kord.extensions.commands.converters.SingleConverter
+import com.kotlindiscord.kord.extensions.commands.converters.Validator
+import com.kotlindiscord.kord.extensions.commands.converters.builders.ConverterBuilder
+import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
+import com.kotlindiscord.kord.extensions.parser.StringParser
+import dev.kord.core.entity.interaction.OptionValue
+import dev.kord.core.entity.interaction.StringOptionValue
+import dev.kord.rest.builder.interaction.OptionsBuilder
+import dev.kord.rest.builder.interaction.StringChoiceBuilder
+import org.koin.core.component.inject
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+
+class ZonedDateTimeConverter(override var validator: Validator<ZonedDateTime> = null) : SingleConverter<ZonedDateTime>(), KordExKoinComponent{
+    override val signatureTypeString: String = "converters.zdt.signatureType"
+
+    private val pattern: String = "d/M/yyyy H:mm"
+
+    private val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d/M/yyyy")
+    private val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern(pattern)
+
+    private val userDatabase: UsersDatabase by inject()
+
+    override suspend fun parse(parser: StringParser?, context: CommandContext, named: String?): Nothing {
+        throw UnsupportedOperationException()
+    }
+
+    override suspend fun parseOption(context: CommandContext, option: OptionValue<*>): Boolean {
+        val optionValue = (option as? StringOptionValue)?.value ?: return false
+
+        val zoneId: ZoneId = userDatabase.getUser(context.getUser()!!.id.value)?.zone
+            ?: throw DiscordRelayedException(context.translate("converters.zdt.error.missingzid"))
+
+        val zonedFormatter = formatter.withZone(zoneId)
+
+        val nSlashes = optionValue.count { it == '/' }
+
+        try {
+            // hacky but easy to implement
+            parsed = if (nSlashes == 2) {
+                ZonedDateTime.parse(optionValue, zonedFormatter)
+            } else {
+                val now = ZonedDateTime.now(zoneId)
+
+                val valueWithYear: String = if (nSlashes == 1) {
+                    optionValue.split(' ').joinToString("/${now.year} ")
+                } else {
+                    now.format(dateFormatter) + ' ' + optionValue.split(' ').last()
+                }
+
+                val parsedWithYear = ZonedDateTime.parse(valueWithYear, zonedFormatter)
+
+                if (parsedWithYear.isBefore(now)) parsedWithYear.withYear(now.year+1)
+                else parsedWithYear
+            }
+        } catch (e: DateTimeParseException) {
+            throw DiscordRelayedException(
+                context.translate("converters.zdt.error.invalid", replacements = arrayOf(pattern))
+            )
+        }
+
+        return true
+    }
+
+    override suspend fun toSlashOption(arg: Argument<*>): OptionsBuilder {
+        return StringChoiceBuilder(arg.displayName, arg.description).apply {
+            maxLength = 25
+            required = true
+        }
+    }
+}
+
+class ZonedDateTimeConverterBuilder : ConverterBuilder<ZonedDateTime>() {
+    override fun build(arguments: Arguments): SingleConverter<ZonedDateTime> {
+        return arguments.arg(name, description, ZonedDateTimeConverter().withBuilder(this))
+    }
+}
+
+fun Arguments.date(body: ZonedDateTimeConverterBuilder.() -> Unit): SingleConverter<ZonedDateTime> {
+    val converterBuilder = ZonedDateTimeConverterBuilder()
+    converterBuilder.body()
+    converterBuilder.validateArgument()
+
+    return converterBuilder.build(this)
+}

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/Scheduler.kt
@@ -1,5 +1,6 @@
 package ar.pelotude.ohhsugoi.db
 
+import dev.kord.core.kordLogger
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.plugins.contentnegotiation.*
@@ -8,36 +9,114 @@ import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.coroutines.*
 import kotlinx.serialization.Serializable
-import java.time.LocalDateTime
+import kotlinx.serialization.SerializationException
+import java.io.IOException
+import java.time.Duration
+import java.time.ZonedDateTime
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.atomic.AtomicLong
-import kotlin.coroutines.CoroutineContext
+import java.util.concurrent.ConcurrentMap
 
-sealed class ScheduleEvent(val post: Scheduler.ScheduledPost)
+sealed class ScheduleEvent<T>(val post: ScheduledPostMetadata<T>)
 
-class Success(post: Scheduler.ScheduledPost): ScheduleEvent(post)
-class Failure(post: Scheduler.ScheduledPost, reason: String): ScheduleEvent(post)
+class Success<T>(post: ScheduledPostMetadata<T>): ScheduleEvent<T>(post)
+class Failure<T>(post: ScheduledPostMetadata<T>, reason: String): ScheduleEvent<T>(post)
 
-interface SchedulerEventHandler {
-    fun handle(e: ScheduleEvent)
+interface SchedulerEventHandler<T> {
+    fun handle(e: ScheduleEvent<T>)
 }
 
-class Scheduler: CoroutineScope {
-    override val coroutineContext: CoroutineContext = SupervisorJob()
+/**
+ * Interface to be implemented by a class that makes the programmed posts
+ * persistent, like a database or a file. All the methods should be
+ * thread-safe.
+ *
+ * Ideally, scheduled announcements should not change their state from sent to
+ * anything else. This means a cancelled or failed post can be sent later on
+ * (even though it's discouraged,) but a sent post should not be changed to cancelled.
+ * or failed.
+ */
+interface ScheduledRegistry<T> {
+    suspend fun insertAnnouncement(content: String, scheduledDateTime: ZonedDateTime): T
 
-    inner class ScheduledPost(val id: Long, val dateTime: LocalDateTime, val text: String) {
-        override fun toString(): String {
-            return "ScheduledPost(id=$id, dateTime=$dateTime, text=\"$text\")"
+    suspend fun markAsCancelled(id: T)
+
+    suspend fun markAsFailed(id: T)
+
+    suspend fun markAsSent(id: T)
+
+    suspend fun getPendingAnnouncements(): Set<ScheduledPostMetadata<T>>
+}
+
+class ScheduledPostMetadata<T>(
+    val id: T,
+    val execTime: ZonedDateTime,
+    val text: String,
+) {
+    override fun toString() = "ScheduledPostMetadata(id=$id, dateTime=$execTime, text=\"$text\")"
+
+    override fun hashCode() = id.hashCode() + execTime.hashCode() + text.hashCode() * 31
+
+    override fun equals(other: Any?): Boolean {
+        return if (other !is ScheduledPostMetadata<*>) false
+        else id == other.id && execTime == other.execTime && text == other.text
+    }
+
+    operator fun component1() = id
+
+    operator fun component2() = execTime
+
+    operator fun component3() = text
+}
+
+class Scheduler<T> private constructor(private val registry: ScheduledRegistry<T>, parent: Job? = null) {
+    companion object {
+        suspend operator fun <T> invoke(registry: ScheduledRegistry<T>, parent: Job? = null) = Scheduler(registry, parent).apply {
+            populate()
         }
+    }
 
-        override fun hashCode() = id.hashCode() + dateTime.hashCode() + text.hashCode() * 31
+    private suspend fun populate() {
+        registry.getPendingAnnouncements().forEach(::loadScheduled)
+    }
+
+    private val supervisorJob = SupervisorJob(parent)
+    private val exceptionHandler = CoroutineExceptionHandler { _, error ->
+        when (error) {
+            is IOException -> kordLogger.error(error) { "The connection in a scheduled post failed." }
+            is SerializationException -> kordLogger.error(error) { "Something went wrong during a post serialization." }
+            else -> throw error
+        }
+    }
+
+    /* scope only meant for scheduled posts */
+    private val scope = CoroutineScope(supervisorJob + exceptionHandler)
+
+    inner class ScheduledPost(
+        private val metadata: ScheduledPostMetadata<T>,
+        private val job: Job,
+    ) {
+        val id
+            get() = metadata.id
+
+        val execTime
+            get() = metadata.execTime
+
+        val text
+            get() = metadata.text
+
+        override fun hashCode() = metadata.hashCode() + job.hashCode() * 17
 
         override fun equals(other: Any?): Boolean {
-            return if (other !is ScheduledPost) false
-            else id == other.id && dateTime == other.dateTime && text == other.text
+            return if (other !is Scheduler<*>.ScheduledPost) false
+            else metadata == other.metadata && job == other.job
         }
 
-        fun cancel() = this@Scheduler.cancel(id)
+        /** Stops this scheduled post locally and then tries to mark it as cancelled in the registry */
+        suspend fun cancel() {
+            job.cancel()
+            registry.markAsCancelled(id)
+        }
+        override fun toString() = "ScheduledPost(id=$id, datetime=$execTime, text=\"$text\", job=$job)"
     }
 
     private val client = HttpClient(CIO) {
@@ -56,52 +135,97 @@ class Scheduler: CoroutineScope {
         }
     }
 
-    private val scheduledPosts: MutableMap<Long, Pair<ScheduledPost, Job>> = ConcurrentHashMap()
+    private val scheduledPosts: ConcurrentMap<T, ScheduledPost> = ConcurrentHashMap()
 
-    private val listeners = mutableListOf<SchedulerEventHandler>()
-
-    private val _ids = AtomicLong(0)
-    private val lastInsertedRow: Long
-        get() = _ids.incrementAndGet()
+    private val listeners = mutableListOf<SchedulerEventHandler<T>>()
 
     private val webhook = System.getenv("DISCORD_WEBHOOK")
 
-    fun schedule(text: String, millis: Long): Long {
-        // TODO: add programmed post to database, then to local map. Remove `AtomicLong` placeholder
-        val thisId = lastInsertedRow
-        val execTime = LocalDateTime.now().plusSeconds(millis / 1000L)
-        val scheduledPost = ScheduledPost(thisId, execTime, text)
+    /** Launches and returns a job for the post described in [metadata].
+     * This is meant to be used internally to construct a [ScheduledPost] to
+     * put into [scheduledPosts]. */
+    private fun launchScheduled(metadata: ScheduledPostMetadata<T>): Job {
+        val (id, execDateTime, text) = metadata
 
-        scheduledPosts[thisId] = scheduledPost to launch {
-            delay(millis)
+        val waitingTime = Duration.between(ZonedDateTime.now(), execDateTime).toMillis()
+
+        return scope.launch {
+            delay(waitingTime)
 
             client.post(webhook) {
                 contentType(ContentType.Application.Json)
-
                 setBody(DiscordHookMessage(content=text))
             }.status.run {
-                // TODO: update database first, mark as done
-                if (value in 200..299) {
-                    listeners.forEach { it.handle(Success(scheduledPost)) }
-                } else {
-                    listeners.forEach { it.handle(Failure(scheduledPost, description)) }
+                // we prevent `markAs...` cancellation to make
+                // sure the new state is reflected in the database
+                val success = withContext(NonCancellable) {
+                    if (value in 200..299) {
+                        registry.markAsSent(id)
+                        true
+                    } else {
+                        registry.markAsFailed(id)
+                        false
+                    }
                 }
-                scheduledPosts.remove(thisId)
+
+                if (success) listeners.forEach { it.handle(Success(metadata)) }
+                else listeners.forEach { it.handle(Failure(metadata, description)) }
             }
         }
-
-        return thisId
     }
 
-    operator fun contains(k: Long) = k in scheduledPosts
+    /** Sets everything up for a job and launches it. This is
+     * meant to be used with posts stored in the registry only. */
+    private fun loadScheduled(metadata: ScheduledPostMetadata<T>) {
+        val job = launchScheduled(metadata)
 
-    operator fun get(k: Long): ScheduledPost? = scheduledPosts[k]?.first
+        val scheduledPost = ScheduledPost(metadata, job)
 
-    fun cancel(k: Long) = scheduledPosts[k]?.let { (sp, job) ->
-        // TODO: remove from database first
-        job.cancel()
-        scheduledPosts.remove(k)
+        scheduledPosts[metadata.id] = scheduledPost
+
+        job.invokeOnCompletion {
+            scheduledPosts.remove(metadata.id)
+        }
     }
+
+    suspend fun schedule(text: String, execDateTime: ZonedDateTime): ScheduledPost {
+        if (!supervisorJob.isActive)
+            throw IllegalStateException("Tried to schedule a post, but the scheduler isn't running")
+
+        val postId = registry.insertAnnouncement(text, execDateTime)
+
+        val metadata = ScheduledPostMetadata(postId, execDateTime, text)
+        val job = launchScheduled(metadata)
+
+        val scheduledPost = ScheduledPost(metadata, job)
+
+        scheduledPosts[postId] = scheduledPost
+
+        // now we know this id's value is present
+        // in the map, so it's safe to remove it
+        // (just in case some madman schedules something 0 seconds ahead)
+        job.invokeOnCompletion {
+            scheduledPosts.remove(postId)
+        }
+
+        return scheduledPost
+    }
+
+    operator fun contains(k: T) = k in scheduledPosts
+
+    operator fun get(k: T): ScheduledPost? = scheduledPosts[k]
+
+    /** Cancels a scheduled post. */
+    suspend fun cancel(k: T) = scheduledPosts[k]?.let { post ->
+        registry.markAsCancelled(k)
+        post.cancel()
+    }
+
+    /** Suspends until this scheduler is stopped. */
+    suspend fun join() = supervisorJob.join()
+
+    /** Stops this scheduler, without affecting the registry. */
+    suspend fun stop() = supervisorJob.cancelAndJoin()
 }
 
 @Serializable

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/Scheduler.kt
@@ -1,0 +1,108 @@
+package ar.pelotude.ohhsugoi.db
+
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.coroutines.*
+import kotlinx.serialization.Serializable
+import java.time.LocalDateTime
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.CoroutineContext
+
+sealed class ScheduleEvent(val post: Scheduler.ScheduledPost)
+
+class Success(post: Scheduler.ScheduledPost): ScheduleEvent(post)
+class Failure(post: Scheduler.ScheduledPost, reason: String): ScheduleEvent(post)
+
+interface SchedulerEventHandler {
+    fun handle(e: ScheduleEvent)
+}
+
+class Scheduler: CoroutineScope {
+    override val coroutineContext: CoroutineContext = SupervisorJob()
+
+    inner class ScheduledPost(val id: Long, val dateTime: LocalDateTime, val text: String) {
+        override fun toString(): String {
+            return "ScheduledPost(id=$id, dateTime=$dateTime, text=\"$text\")"
+        }
+
+        override fun hashCode() = id.hashCode() + dateTime.hashCode() + text.hashCode() * 31
+
+        override fun equals(other: Any?): Boolean {
+            return if (other !is ScheduledPost) false
+            else id == other.id && dateTime == other.dateTime && text == other.text
+        }
+
+        fun cancel() = this@Scheduler.cancel(id)
+    }
+
+    private val client = HttpClient(CIO) {
+        install(ContentNegotiation) {
+            json()
+        }
+
+        engine {
+            maxConnectionsCount = 4
+            threadsCount = 2
+
+            endpoint {
+                connectAttempts = 5
+                connectTimeout = 15_000
+            }
+        }
+    }
+
+    private val scheduledPosts: MutableMap<Long, Pair<ScheduledPost, Job>> = ConcurrentHashMap()
+
+    private val listeners = mutableListOf<SchedulerEventHandler>()
+
+    private val _ids = AtomicLong(0)
+    private val lastInsertedRow: Long
+        get() = _ids.incrementAndGet()
+
+    private val webhook = System.getenv("DISCORD_WEBHOOK")
+
+    fun schedule(text: String, millis: Long): Long {
+        // TODO: add programmed post to database, then to local map. Remove `AtomicLong` placeholder
+        val thisId = lastInsertedRow
+        val execTime = LocalDateTime.now().plusSeconds(millis / 1000L)
+        val scheduledPost = ScheduledPost(thisId, execTime, text)
+
+        scheduledPosts[thisId] = scheduledPost to launch {
+            delay(millis)
+
+            client.post(webhook) {
+                contentType(ContentType.Application.Json)
+
+                setBody(DiscordHookMessage(content=text))
+            }.status.run {
+                // TODO: update database first, mark as done
+                if (value in 200..299) {
+                    listeners.forEach { it.handle(Success(scheduledPost)) }
+                } else {
+                    listeners.forEach { it.handle(Failure(scheduledPost, description)) }
+                }
+                scheduledPosts.remove(thisId)
+            }
+        }
+
+        return thisId
+    }
+
+    operator fun contains(k: Long) = k in scheduledPosts
+
+    operator fun get(k: Long): ScheduledPost? = scheduledPosts[k]?.first
+
+    fun cancel(k: Long) = scheduledPosts[k]?.let { (sp, job) ->
+        // TODO: remove from database first
+        job.cancel()
+        scheduledPosts.remove(k)
+    }
+}
+
+@Serializable
+data class DiscordHookMessage(val username: String="Sheska", val content: String)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/UsersAPI.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/UsersAPI.kt
@@ -1,0 +1,11 @@
+package ar.pelotude.ohhsugoi.db
+
+import java.time.ZoneId
+
+data class UserData(val snowflakeId: ULong, val zone: ZoneId?)
+
+interface UsersDatabase {
+    suspend fun setUser(user: UserData)
+
+    suspend fun getUser(snowflake: ULong): UserData?
+}

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/DiscordHookMessage.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/DiscordHookMessage.kt
@@ -3,4 +3,14 @@ package ar.pelotude.ohhsugoi.db.scheduler
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class DiscordHookMessage(val username: String="Sheska", val content: String)
+data class DiscordHookMessageEmbed(
+        val title: String?,
+        val description: String,
+)
+
+@Serializable
+data class DiscordHookMessage(
+        val username: String="Sheska",
+        val content: String? = null,
+        val embeds: Collection<DiscordHookMessageEmbed>? = null,
+)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/DiscordHookMessage.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/DiscordHookMessage.kt
@@ -1,0 +1,6 @@
+package ar.pelotude.ohhsugoi.db.scheduler
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class DiscordHookMessage(val username: String="Sheska", val content: String)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/DiscordHookMessage.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/DiscordHookMessage.kt
@@ -4,13 +4,13 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class DiscordHookMessageEmbed(
-        val title: String?,
+        val title: String? = null,
         val description: String,
 )
 
 @Serializable
 data class DiscordHookMessage(
-        val username: String="Sheska",
+        val username: String = "Sheska",
         val content: String? = null,
         val embeds: Collection<DiscordHookMessageEmbed>? = null,
 )

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
@@ -1,24 +1,24 @@
 package ar.pelotude.ohhsugoi.db.scheduler
 
-import java.time.ZonedDateTime
+import java.time.Instant
 
 class ScheduledPostMetadata<T>(
     val id: T,
-    val execTime: ZonedDateTime,
+    val execInstant: Instant,
     val text: String,
 ) {
-    override fun toString() = "ScheduledPostMetadata(id=$id, dateTime=$execTime, text=\"$text\")"
+    override fun toString() = "ScheduledPostMetadata(id=$id, dateTime=$execInstant, text=\"$text\")"
 
-    override fun hashCode() = id.hashCode() + execTime.hashCode() + text.hashCode() * 31
+    override fun hashCode() = id.hashCode() + execInstant.hashCode() + text.hashCode() * 31
 
     override fun equals(other: Any?): Boolean {
         return if (other !is ScheduledPostMetadata<*>) false
-        else id == other.id && execTime == other.execTime && text == other.text
+        else id == other.id && execInstant == other.execInstant && text == other.text
     }
 
     operator fun component1() = id
 
-    operator fun component2() = execTime
+    operator fun component2() = execInstant
 
     operator fun component3() = text
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
@@ -9,18 +9,27 @@ enum class Status(val code: Long) {
     FAILED(3),
 }
 
-class ScheduledPostMetadata<T>(
-    val id: T,
-    val execInstant: Instant,
-    val text: String,
-    val status: Status = Status.PENDING,
-) {
+interface ScheduledPostMetadata<T> {
+    val id: T
+    val execInstant: Instant
+    val text: String
+    val mentionId: ULong?
+    val status: Status
+}
+
+class ScheduledPostMetadataImpl<T>(
+        override val id: T,
+        override val execInstant: Instant,
+        override val text: String,
+        override val mentionId: ULong?,
+        override val status: Status = Status.PENDING,
+) : ScheduledPostMetadata<T> {
     override fun toString() = "ScheduledPostMetadata(id=$id, dateTime=$execInstant, text=\"$text\")"
 
     override fun hashCode() = id.hashCode() + execInstant.hashCode() + text.hashCode() * 31
 
     override fun equals(other: Any?): Boolean {
-        return if (other !is ScheduledPostMetadata<*>) false
+        return if (other !is ScheduledPostMetadataImpl<*>) false
         else id == other.id && execInstant == other.execInstant && text == other.text
     }
 
@@ -29,4 +38,8 @@ class ScheduledPostMetadata<T>(
     operator fun component2() = execInstant
 
     operator fun component3() = text
+
+    operator fun component4() = mentionId
+
+    operator fun component5() = status
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
@@ -2,10 +2,18 @@ package ar.pelotude.ohhsugoi.db.scheduler
 
 import java.time.Instant
 
+enum class Status(val code: Long) {
+    PENDING(0),
+    SENT(1),
+    CANCELLED(2),
+    FAILED(3),
+}
+
 class ScheduledPostMetadata<T>(
     val id: T,
     val execInstant: Instant,
     val text: String,
+    val status: Status = Status.PENDING,
 ) {
     override fun toString() = "ScheduledPostMetadata(id=$id, dateTime=$execInstant, text=\"$text\")"
 

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledPostMetadata.kt
@@ -1,0 +1,24 @@
+package ar.pelotude.ohhsugoi.db.scheduler
+
+import java.time.ZonedDateTime
+
+class ScheduledPostMetadata<T>(
+    val id: T,
+    val execTime: ZonedDateTime,
+    val text: String,
+) {
+    override fun toString() = "ScheduledPostMetadata(id=$id, dateTime=$execTime, text=\"$text\")"
+
+    override fun hashCode() = id.hashCode() + execTime.hashCode() + text.hashCode() * 31
+
+    override fun equals(other: Any?): Boolean {
+        return if (other !is ScheduledPostMetadata<*>) false
+        else id == other.id && execTime == other.execTime && text == other.text
+    }
+
+    operator fun component1() = id
+
+    operator fun component2() = execTime
+
+    operator fun component3() = text
+}

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
@@ -20,5 +20,5 @@ interface ScheduledRegistry<T> {
 
     suspend fun markAsSent(id: T)
 
-    suspend fun getPendingAnnouncements(): Set<ScheduledPostMetadata<T>>
+    suspend fun getAnnouncements(status: Status?): Set<ScheduledPostMetadata<T>>
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
@@ -1,6 +1,6 @@
 package ar.pelotude.ohhsugoi.db.scheduler
 
-import java.time.ZonedDateTime
+import java.time.Instant
 
 /**
  * Interface to be implemented by a class that makes the programmed posts
@@ -12,7 +12,7 @@ import java.time.ZonedDateTime
  * (even though it's discouraged,) but a sent post should not be changed to cancelled.
  * or failed. */
 interface ScheduledRegistry<T> {
-    suspend fun insertAnnouncement(content: String, scheduledDateTime: ZonedDateTime): T
+    suspend fun insertAnnouncement(content: String, scheduledDateTime: Instant): T
 
     suspend fun markAsCancelled(id: T)
 

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
@@ -12,13 +12,15 @@ import java.time.Instant
  * (even though it's discouraged,) but a sent post should not be changed to cancelled.
  * or failed. */
 interface ScheduledRegistry<T> {
-    suspend fun insertAnnouncement(content: String, scheduledDateTime: Instant): T
+    suspend fun insertAnnouncement(content: String, scheduledDateTime: Instant, mentionId: ULong?): T
 
-    suspend fun markAsCancelled(id: T)
+    suspend fun markAsCancelled(id: T): Boolean
 
-    suspend fun markAsFailed(id: T)
+    suspend fun markAsFailed(id: T): Boolean
 
-    suspend fun markAsSent(id: T)
+    suspend fun markAsSent(id: T): Boolean
 
-    suspend fun getAnnouncements(status: Status?): Set<ScheduledPostMetadata<T>>
+    suspend fun getAnnouncements(status: Status?): Set<ScheduledPostMetadataImpl<T>>
+
+    suspend fun getAnnouncement(id: T): ScheduledPostMetadataImpl<T>?
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
@@ -23,4 +23,8 @@ interface ScheduledRegistry<T> {
     suspend fun getAnnouncements(status: Status?): Set<ScheduledPostMetadataImpl<T>>
 
     suspend fun getAnnouncement(id: T): ScheduledPostMetadataImpl<T>?
+
+    suspend fun editAnnouncement(id: T, content: String?, scheduledDateTime: Instant?, mentionRole: ULong?): Boolean
+
+    suspend fun removeMentionRoleFrom(id: T): Boolean
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/ScheduledRegistry.kt
@@ -1,0 +1,24 @@
+package ar.pelotude.ohhsugoi.db.scheduler
+
+import java.time.ZonedDateTime
+
+/**
+ * Interface to be implemented by a class that makes the programmed posts
+ * persistent, like a database or a file. All the methods should be
+ * thread-safe.
+ *
+ * Ideally, scheduled announcements should not change their state from sent to
+ * anything else. This means a cancelled or failed post can be sent later on
+ * (even though it's discouraged,) but a sent post should not be changed to cancelled.
+ * or failed. */
+interface ScheduledRegistry<T> {
+    suspend fun insertAnnouncement(content: String, scheduledDateTime: ZonedDateTime): T
+
+    suspend fun markAsCancelled(id: T)
+
+    suspend fun markAsFailed(id: T)
+
+    suspend fun markAsSent(id: T)
+
+    suspend fun getPendingAnnouncements(): Set<ScheduledPostMetadata<T>>
+}

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
@@ -4,6 +4,7 @@ import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
 import dev.kord.core.kordLogger
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.http.*
@@ -68,6 +69,14 @@ class Scheduler<T> (private val registry: ScheduledRegistry<T>, parent: Job? = n
     private val client = HttpClient(CIO) {
         install(ContentNegotiation) {
             json()
+        }
+
+        install(HttpRequestRetry) {
+            maxRetries = 3
+            retryIf { _, response -> !response.status.isSuccess() }
+            delayMillis { retry: Int ->
+                retry * 5000L
+            }
         }
 
         engine {

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
@@ -33,12 +33,7 @@ class Scheduler<T> (private val registry: ScheduledRegistry<T>, parent: Job? = n
     }
 
     /* scope only meant for scheduled posts */
-    private val scope = CoroutineScope(supervisorJob + exceptionHandler).apply {
-        launch {
-            delay(1000)
-            registry.getAnnouncements(Status.PENDING).forEach(::loadScheduled)
-        }
-    }
+    private val scope = CoroutineScope(supervisorJob + exceptionHandler)
 
     private inner class ScheduledPost(
             private val metadata: ScheduledPostMetadataImpl<T>,

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
@@ -104,11 +104,10 @@ class Scheduler<T> (private val registry: ScheduledRegistry<T>, parent: Job? = n
                 contentType(ContentType.Application.Json)
                 setBody(
                         DiscordHookMessage(
-                                content = mention,
-                                embeds = listOf(
+                                content=mention,
+                                embeds=listOf(
                                         DiscordHookMessageEmbed(
-                                                null,
-                                                text
+                                            description=text
                                         )
                                 )
                         )

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
@@ -176,4 +176,8 @@ class Scheduler<T> (private val registry: ScheduledRegistry<T>, parent: Job? = n
     fun subscribe(o: SchedulerEventHandler<T>) = listeners.add(o)
 
     fun unsubscribe(o: SchedulerEventHandler<T>) = listeners.remove(o)
+
+    suspend fun getPosts(statusFilter: Status? = Status.PENDING): Set<ScheduledPostMetadata<T>> {
+        return registry.getAnnouncements(statusFilter)
+    }
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/Scheduler.kt
@@ -1,5 +1,6 @@
 package ar.pelotude.ohhsugoi.db.scheduler
 
+import com.kotlindiscord.kord.extensions.koin.KordExKoinComponent
 import dev.kord.core.kordLogger
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
@@ -90,7 +91,7 @@ class Scheduler<T> private constructor(private val registry: ScheduledRegistry<T
 
     private val listeners = CopyOnWriteArrayList<SchedulerEventHandler<T>>()
 
-    private val webhook = System.getenv("DISCORD_WEBHOOK")
+    private val webhook: String by inject(qualifier = named("hookToken"))
 
     /** Launches and returns a job for the post described in [metadata].
      * This is meant to be used internally to construct a [ScheduledPost] to

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerConfiguration.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerConfiguration.kt
@@ -1,0 +1,6 @@
+package ar.pelotude.ohhsugoi.db.scheduler
+
+class SchedulerConfiguration(
+    val discordGuildId: ULong,
+    val webhook: String,
+)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerEventHandler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerEventHandler.kt
@@ -1,0 +1,9 @@
+package ar.pelotude.ohhsugoi.db.scheduler
+
+interface SchedulerEventHandler<T> {
+    fun handle(e: ScheduleEvent<T>)
+}
+
+sealed class ScheduleEvent<T>(val post: ScheduledPostMetadata<T>)
+class Success<T>(post: ScheduledPostMetadata<T>): ScheduleEvent<T>(post)
+class Failure<T>(post: ScheduledPostMetadata<T>, reason: String): ScheduleEvent<T>(post)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerEventHandler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerEventHandler.kt
@@ -6,4 +6,4 @@ interface SchedulerEventHandler<T> {
 
 sealed class ScheduleEvent<T>(val post: ScheduledPostMetadata<T>)
 class Success<T>(post: ScheduledPostMetadata<T>): ScheduleEvent<T>(post)
-class Failure<T>(post: ScheduledPostMetadata<T>, reason: String): ScheduleEvent<T>(post)
+class Failure<T>(post: ScheduledPostMetadata<T>, val reason: String): ScheduleEvent<T>(post)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerEventHandler.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/db/scheduler/SchedulerEventHandler.kt
@@ -4,6 +4,6 @@ interface SchedulerEventHandler<T> {
     fun handle(e: ScheduleEvent<T>)
 }
 
-sealed class ScheduleEvent<T>(val post: ScheduledPostMetadata<T>)
-class Success<T>(post: ScheduledPostMetadata<T>): ScheduleEvent<T>(post)
-class Failure<T>(post: ScheduledPostMetadata<T>, val reason: String): ScheduleEvent<T>(post)
+sealed class ScheduleEvent<T>(val post: ScheduledPostMetadataImpl<T>)
+class Success<T>(post: ScheduledPostMetadataImpl<T>): ScheduleEvent<T>(post)
+class Failure<T>(post: ScheduledPostMetadataImpl<T>, val reason: String): ScheduleEvent<T>(post)

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
@@ -4,8 +4,11 @@ import ar.pelotude.ohhsugoi.bot.MangaExtensionConfiguration
 import ar.pelotude.ohhsugoi.db.DatabaseConfiguration
 import ar.pelotude.ohhsugoi.db.MangaDatabase
 import ar.pelotude.ohhsugoi.db.MangaDatabaseSQLite
+import ar.pelotude.ohhsugoi.db.UsersDatabase
 import ar.pelotude.ohhsugoi.db.scheduler.ScheduledRegistry
 import ar.pelotude.ohhsugoi.db.scheduler.Scheduler
+import com.kotlindiscord.kord.extensions.DiscordRelayedException
+import com.kotlindiscord.kord.extensions.commands.CommandContext
 import dev.kord.common.entity.Snowflake
 import io.ktor.http.*
 import org.koin.core.qualifier.named
@@ -15,9 +18,19 @@ import java.nio.file.Path
 import kotlin.io.path.createDirectories
 
 val botModule = module {
-    single { MangaDatabaseSQLite() }.binds(arrayOf(MangaDatabase::class, ScheduledRegistry::class))
+    single { MangaDatabaseSQLite() } binds arrayOf(MangaDatabase::class, ScheduledRegistry::class, UsersDatabase::class)
 
     single<Scheduler<Long>> { Scheduler(get()) }
+
+    single<suspend (String, CommandContext) -> Long> {
+        { value, context ->
+            try {
+                value.toLong()
+            } catch (e: NumberFormatException) {
+                throw DiscordRelayedException(context.translate("converters.zdt.error.missingzid"))
+            }
+        }
+    }
 
     single<MangaExtensionConfiguration> {
         MangaExtensionConfiguration(

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
@@ -4,14 +4,21 @@ import ar.pelotude.ohhsugoi.bot.MangaExtensionConfiguration
 import ar.pelotude.ohhsugoi.db.DatabaseConfiguration
 import ar.pelotude.ohhsugoi.db.MangaDatabase
 import ar.pelotude.ohhsugoi.db.MangaDatabaseSQLite
+import ar.pelotude.ohhsugoi.db.scheduler.ScheduledRegistry
+import ar.pelotude.ohhsugoi.db.scheduler.Scheduler
 import dev.kord.common.entity.Snowflake
 import io.ktor.http.*
+import org.koin.core.qualifier.named
+import org.koin.dsl.binds
 import org.koin.dsl.module
 import java.nio.file.Path
 import kotlin.io.path.createDirectories
 
 val botModule = module {
-    single<MangaDatabase> { MangaDatabaseSQLite() }
+    single { MangaDatabaseSQLite() }.binds(arrayOf(MangaDatabase::class, ScheduledRegistry::class))
+
+    single<Scheduler<Long>> { Scheduler(get()) }
+
     single<MangaExtensionConfiguration> {
         MangaExtensionConfiguration(
             Snowflake(System.getenv("KORD_WEEB_SERVER")!!),
@@ -33,5 +40,9 @@ val botModule = module {
             System.getenv("MANGA_COVERS_URL_SUBDIRECTORY"),
             Path.of(System.getenv("SQLITE_FILE_PATH")!!).apply { parent.createDirectories() }.toString(),
         )
+    }
+
+    single<String>(named("hookToken")) {
+        System.getenv("DISCORD_WEBHOOK")
     }
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
@@ -3,6 +3,7 @@ package ar.pelotude.ohhsugoi.koin
 import ar.pelotude.ohhsugoi.bot.GeneralConfiguration
 import ar.pelotude.ohhsugoi.bot.GeneralConfigurationImpl
 import ar.pelotude.ohhsugoi.bot.MangaExtensionConfiguration
+import ar.pelotude.ohhsugoi.bot.UtilsExtensionConfiguration
 import ar.pelotude.ohhsugoi.db.DatabaseConfiguration
 import ar.pelotude.ohhsugoi.db.MangaDatabase
 import ar.pelotude.ohhsugoi.db.MangaDatabaseSQLite
@@ -61,6 +62,13 @@ val botModule = module {
             Path.of(System.getenv("MANGA_IMAGE_DIRECTORY")),
             System.getenv("MANGA_COVERS_URL_SUBDIRECTORY"),
             Path.of(System.getenv("SQLITE_FILE_PATH")!!).apply { parent.createDirectories() }.toString(),
+        )
+    }
+
+    single<UtilsExtensionConfiguration> {
+        UtilsExtensionConfiguration(
+                Snowflake(System.getenv("DISCORD_HELPER_ROLE")!!),
+                get(),
         )
     }
 

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
@@ -7,11 +7,11 @@ import ar.pelotude.ohhsugoi.db.MangaDatabaseSQLite
 import ar.pelotude.ohhsugoi.db.UsersDatabase
 import ar.pelotude.ohhsugoi.db.scheduler.ScheduledRegistry
 import ar.pelotude.ohhsugoi.db.scheduler.Scheduler
+import ar.pelotude.ohhsugoi.db.scheduler.SchedulerConfiguration
 import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import dev.kord.common.entity.Snowflake
 import io.ktor.http.*
-import org.koin.core.qualifier.named
 import org.koin.dsl.binds
 import org.koin.dsl.module
 import java.nio.file.Path
@@ -55,7 +55,10 @@ val botModule = module {
         )
     }
 
-    single<String>(named("hookToken")) {
-        System.getenv("DISCORD_WEBHOOK")
+    single<SchedulerConfiguration> {
+        SchedulerConfiguration(
+                System.getenv("KORD_WEEB_SERVER")!!.toULong(),
+                System.getenv("DISCORD_WEBHOOK"),
+        )
     }
 }

--- a/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
+++ b/src/main/kotlin/ar/pelotude/ohhsugoi/koin/BotInjections.kt
@@ -1,5 +1,7 @@
 package ar.pelotude.ohhsugoi.koin
 
+import ar.pelotude.ohhsugoi.bot.GeneralConfiguration
+import ar.pelotude.ohhsugoi.bot.GeneralConfigurationImpl
 import ar.pelotude.ohhsugoi.bot.MangaExtensionConfiguration
 import ar.pelotude.ohhsugoi.db.DatabaseConfiguration
 import ar.pelotude.ohhsugoi.db.MangaDatabase
@@ -12,6 +14,7 @@ import com.kotlindiscord.kord.extensions.DiscordRelayedException
 import com.kotlindiscord.kord.extensions.commands.CommandContext
 import dev.kord.common.entity.Snowflake
 import io.ktor.http.*
+import org.koin.core.qualifier.named
 import org.koin.dsl.binds
 import org.koin.dsl.module
 import java.nio.file.Path
@@ -32,22 +35,28 @@ val botModule = module {
         }
     }
 
+    single<GeneralConfiguration> {
+        GeneralConfigurationImpl(
+            Snowflake(System.getenv("KORD_WEEB_SERVER")!!),
+        )
+    }
+
     single<MangaExtensionConfiguration> {
         MangaExtensionConfiguration(
-            Snowflake(System.getenv("KORD_WEEB_SERVER")!!),
             Snowflake(System.getenv("KORD_WEEB_ROLE")!!),
-            256,
-            1,
-            100,
-            20,
-            512,
+            mangaLinkMaxLength=256,
+            mangaTitleMinLength=1,
+            mangaTitleMaxLength=100,
+            mangaDescMinLength=20,
+            mangaDescMaxLength=512,
+            get<GeneralConfiguration>(),
         )
     }
 
     single<DatabaseConfiguration> {
         DatabaseConfiguration(
-            225,
-            340,
+            mangaCoversWidth=225,
+            mangaCoversHeight=340,
             Url(System.getenv("WEBPAGE")),
             Path.of(System.getenv("MANGA_IMAGE_DIRECTORY")),
             System.getenv("MANGA_COVERS_URL_SUBDIRECTORY"),
@@ -60,5 +69,9 @@ val botModule = module {
                 System.getenv("KORD_WEEB_SERVER")!!.toULong(),
                 System.getenv("DISCORD_WEBHOOK"),
         )
+    }
+
+    single<Snowflake>(named("loggerChannel")) {
+        Snowflake(System.getenv("DISCORD_LOGGER_CHANNEL").toLong())
     }
 }

--- a/src/main/resources/translations/kordex/strings_override_es.properties
+++ b/src/main/resources/translations/kordex/strings_override_es.properties
@@ -5,3 +5,6 @@ paginator.button.group.switch=Siguiente grupo
 paginator.button.less=Menos
 paginator.footer.page=Página {0}/{1}
 paginator.footer.group=Grupo {0}/{1}
+converters.zdt.error.invalid=Formato de fecha inválida. Utiliza el formato `{0}`.
+converters.zdt.error.missingzid=No tengo datos de tu zona horaria.
+converters.zdt.signatureType=Fecha y hora

--- a/src/main/sqldelight/manga/Manga.sq
+++ b/src/main/sqldelight/manga/Manga.sq
@@ -48,6 +48,7 @@ CREATE TABLE scheduled_announcement(
   id INTEGER PRIMARY KEY NOT NULL,
   content TEXT NOT NULL,
   scheduled_date INTEGER NOT NULL,
+  mention_snowflake_id TEXT,
   status TEXT NOT NULL DEFAULT 'PENDING' -- PENDING, SENT, CANCELLED, FAILED
 );
 
@@ -56,7 +57,7 @@ CREATE TABLE discord_user_timezone(
   timezone TEXT
 );
 
-PRAGMA user_version = 2;
+PRAGMA user_version = 3;
 
 searchTagTitle:
 SELECT t.title FROM tag t WHERE title LIKE :name || '%' LIMIT :limit;
@@ -182,23 +183,40 @@ HAVING MAX(tag.title = :tag_filter) OR :tag_filter IS NULL
 LIMIT :limit;
 
 insertAnnouncement:
-INSERT INTO scheduled_announcement(content, scheduled_date) VALUES(:content, :scheduled_date) RETURNING id;
+INSERT INTO scheduled_announcement(content, scheduled_date, mention_snowflake_id)
+VALUES(:content, :scheduled_date, :mention_id) RETURNING id;
 
 markAnnouncementAsSent:
-UPDATE scheduled_announcement SET status = 'SENT' WHERE id = :id;
+UPDATE scheduled_announcement SET status = 'SENT' WHERE id = :id RETURNING id;
 
 markAnnouncementAsCancelled:
-UPDATE scheduled_announcement SET status = 'CANCELLED' WHERE id = :id;
+UPDATE scheduled_announcement SET status = 'CANCELLED' WHERE id = :id AND status = 'PENDING' RETURNING id;
 
 markAnnouncementAsFailed:
-UPDATE scheduled_announcement SET status = 'FAILED' WHERE id = :id;
+UPDATE scheduled_announcement SET status = 'FAILED' WHERE id = :id AND status = 'PENDING' RETURNING id;
+
+selectAnnouncement:
+SELECT id, content, scheduled_date, mention_snowflake_id, status FROM scheduled_announcement WHERE id = :announcement_id;
 
 selectAnnouncements:
-SELECT id, content, scheduled_date, status FROM scheduled_announcement WHERE status = :status OR :status IS NULL;
+SELECT id, content, scheduled_date, mention_snowflake_id, status FROM scheduled_announcement WHERE status = :status OR :status IS NULL;
+
+editAnnouncement:
+UPDATE scheduled_announcement
+SET
+  content = CASE WHEN :content IS NULL THEN content ELSE :content END,
+  mention_snowflake_id = CASE WHEN :mentionId IS NULL THEN mention_snowflake_id ELSE :mentionId END,
+  scheduled_date = CASE WHEN :date IS NULL THEN scheduled_date ELSE :date END
+WHERE id = :id AND status = 'PENDING'
+RETURNING id;
+
+unsetMentionFromAnnouncement:
+UPDATE scheduled_announcement
+SET mention_snowflake_id = NULL WHERE id = :id AND status = 'PENDING' RETURNING id;
 
 insertUser:
 INSERT INTO discord_user_timezone(snowflake_id, timezone) VALUES (:snowflake_id, :timezone)
-ON CONFLICT(snowflake_id) DO UPDATE SET timezone=:timezone;
+ON CONFLICT(snowflake_id) DO UPDATE SET timezone = :timezone;
 
 getUser:
 SELECT dut.snowflake_id, dut.timezone FROM discord_user_timezone dut WHERE snowflake_id = :snowflake_id;

--- a/src/main/sqldelight/manga/Manga.sq
+++ b/src/main/sqldelight/manga/Manga.sq
@@ -51,6 +51,11 @@ CREATE TABLE scheduled_announcement(
   status TEXT NOT NULL DEFAULT 'PENDING' -- PENDING, SENT, CANCELLED, FAILED
 );
 
+CREATE TABLE discord_user_timezone(
+  snowflake_id TEXT PRIMARY KEY NOT NULL,
+  timezone TEXT
+);
+
 PRAGMA user_version = 2;
 
 searchTagTitle:
@@ -190,3 +195,10 @@ UPDATE scheduled_announcement SET status = 'FAILED' WHERE id = :id;
 
 selectAnnouncements:
 SELECT id, content, scheduled_date, status FROM scheduled_announcement WHERE status = :status OR :status IS NULL;
+
+insertUser:
+INSERT INTO discord_user_timezone(snowflake_id, timezone) VALUES (:snowflake_id, :timezone)
+ON CONFLICT(snowflake_id) DO UPDATE SET timezone=:timezone;
+
+getUser:
+SELECT dut.snowflake_id, dut.timezone FROM discord_user_timezone dut WHERE snowflake_id = :snowflake_id;

--- a/src/main/sqldelight/manga/Manga.sq
+++ b/src/main/sqldelight/manga/Manga.sq
@@ -44,6 +44,13 @@ BEGIN
     UPDATE mangafts SET title = new.title WHERE manga_id = new.id;
 END;
 
+CREATE TABLE scheduled_announcement(
+  id INTEGER PRIMARY KEY NOT NULL,
+  content TEXT NOT NULL,
+  scheduled_date INTEGER NOT NULL,
+  status TEXT NOT NULL DEFAULT 'PENDING' -- PENDING, SENT, CANCELLED, FAILED
+);
+
 PRAGMA user_version = 2;
 
 searchTagTitle:
@@ -168,3 +175,18 @@ WHERE manga.deleted = 0
 GROUP BY manga.id
 HAVING MAX(tag.title = :tag_filter) OR :tag_filter IS NULL
 LIMIT :limit;
+
+insertAnnouncement:
+INSERT INTO scheduled_announcement(content, scheduled_date) VALUES(:content, :scheduled_date) RETURNING id;
+
+markAnnouncementAsSent:
+UPDATE scheduled_announcement SET status = 'SENT' WHERE id = :id;
+
+markAnnouncementAsCancelled:
+UPDATE scheduled_announcement SET status = 'CANCELLED' WHERE id = :id;
+
+markAnnouncementAsFailed:
+UPDATE scheduled_announcement SET status = 'FAILED' WHERE id = :id;
+
+selectAnnouncements:
+SELECT id, content, scheduled_date, status FROM scheduled_announcement WHERE status = :status OR :status IS NULL;

--- a/src/main/sqldelight/migrations/2.sqm
+++ b/src/main/sqldelight/migrations/2.sqm
@@ -1,0 +1,14 @@
+CREATE TABLE scheduled_announcement(
+  id INTEGER PRIMARY KEY NOT NULL,
+  content TEXT NOT NULL,
+  scheduled_date INTEGER NOT NULL,
+  mention_snowflake_id TEXT,
+  status TEXT NOT NULL DEFAULT 'PENDING' -- PENDING, SENT, CANCELLED, FAILED
+);
+
+CREATE TABLE discord_user_timezone(
+  snowflake_id TEXT PRIMARY KEY NOT NULL,
+  timezone TEXT
+);
+
+PRAGMA user_version = 3;


### PR DESCRIPTION
This update requires a new member role, a new webook and a new channel id. Their descriptions can be found in the README.

The following features were added:
1) Users with the proper role can schedule messages to be send to the new specified channel. They can also edit the messages or cancel them. Every message is composed of a date, a text, and an optional role to be mentioned. If the messages was successfully scheduled but something fails at the moment of sending it, then an error is shown in the logger channel. The reason the announcements are sent via this webook and not Sheska herself is because I want to split the bot functionality and the database+scheduler later later on (everything is up to change anyway).
2) Users can set a time zone. This is required to create scheduled messages.

We should support tweets next.